### PR TITLE
Enable insecure connections for dotnet restore command.

### DIFF
--- a/vars/commons.groovy
+++ b/vars/commons.groovy
@@ -22,7 +22,7 @@ def makeVersion() {
 
 def dotnetBuild() {
   powershell "dotnet --version"
-  powershell "dotnet restore"
+  powershell "dotnet restore --allow-insecure-connections"
   powershell "dotnet clean . -c Release"
   powershell "dotnet build . -c Release /p:Version=${env.GIT_VERSION}"
 }


### PR DESCRIPTION
Jenkins fails to build QP models due to http connection to Artifactory. LLMs suggest adding --allow-insecure-connections to dotnet restore to fix the issue.